### PR TITLE
Default noun

### DIFF
--- a/icanhaz.py
+++ b/icanhaz.py
@@ -8,7 +8,7 @@ def haz(**kw):
 
 def main(argv=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('noun', nargs='?', default='gitburger')
+    parser.add_argument('noun', nargs='?', default='gitflow')
     parser.add_argument('pronoun', nargs='?', default='we')
     args = parser.parse_args(argv)
     haz(**vars(args))

--- a/icanhaz.py
+++ b/icanhaz.py
@@ -8,7 +8,7 @@ def haz(**kw):
 
 def main(argv=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('noun')
+    parser.add_argument('noun', nargs='?', default='gitburger')
     args = parser.parse_args(argv)
     haz(**vars(args))
     return 0

--- a/icanhaz.py
+++ b/icanhaz.py
@@ -4,7 +4,7 @@ import argparse
 
 
 def haz(**kw):
-    print('{pronoun} can haz {noun}'.format(**kw))
+    print('{pronoun} can haz {noun}?'.format(**kw))
 
 def main(argv=None):
     parser = argparse.ArgumentParser()

--- a/icanhaz.py
+++ b/icanhaz.py
@@ -4,11 +4,12 @@ import argparse
 
 
 def haz(**kw):
-    print('i can haz {noun}'.format(**kw))
+    print('{pronoun} can haz {noun}'.format(**kw))
 
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('noun', nargs='?', default='gitburger')
+    parser.add_argument('pronoun', nargs='?', default='we')
     args = parser.parse_args(argv)
     haz(**vars(args))
     return 0


### PR DESCRIPTION
This feature adds a default noun and pronoun.

This is not yet rebased. In this example, we use `git commit --fixup=68e7953` in the last commit to fix the first commit, which was typed in wrong. You can see the results of an autosquash in the `default-noun-autosquashed` branch.
